### PR TITLE
Add in new changes to set to proper environment ids

### DIFF
--- a/.github/workflows/apply_plan.yaml
+++ b/.github/workflows/apply_plan.yaml
@@ -57,4 +57,5 @@ jobs:
           TF_VAR_boomi_account_id: ${{ secrets.TF_VAR_BOOMI_ACCOUNT_ID }}
           TF_VAR_boomi_auth_token: ${{ secrets.TF_VAR_BOOMI_AUTH_TOKEN }}
           TF_VAR_boomi_username: ${{ secrets.TF_VAR_BOOMI_USERNAME }}
+          TF_VAR_boomi_environment_id: ${{ secrets.TF_VAR_BOOMI_ENVIRONMENT_ID }}
           TF_VAR_owner: ${{ secrets.TF_VAR_OWNER }}

--- a/.github/workflows/create_plan.yaml
+++ b/.github/workflows/create_plan.yaml
@@ -52,4 +52,5 @@ jobs:
           TF_VAR_boomi_account_id: ${{ secrets.TF_VAR_BOOMI_ACCOUNT_ID }}
           TF_VAR_boomi_auth_token: ${{ secrets.TF_VAR_BOOMI_AUTH_TOKEN }}
           TF_VAR_boomi_username: ${{ secrets.TF_VAR_BOOMI_USERNAME }}
+          TF_VAR_boomi_environment_id: ${{ secrets.TF_VAR_BOOMI_ENVIRONMENT_ID }}
           TF_VAR_owner: ${{ secrets.TF_VAR_OWNER }}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repo is configured for the intention of use for Coforma. If you intend to u
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | < 1.6 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.19.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.30.0 |
 
 ## Providers
 
@@ -30,10 +30,10 @@ This repo is configured for the intention of use for Coforma. If you intend to u
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | ~> 5.2.2 |
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | ~> 6.0.1 |
+| <a name="module_ecs"></a> [ecs](#module\_ecs) | terraform-aws-modules/ecs/aws | ~> 5.7.0 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | ~> 6.5.0 |
 | <a name="module_secrets_manager"></a> [secrets\_manager](#module\_secrets\_manager) | terraform-aws-modules/secrets-manager/aws | ~> 1.1.1 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.1.2 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.4.0 |
 
 ## Resources
 
@@ -70,6 +70,7 @@ This repo is configured for the intention of use for Coforma. If you intend to u
 | <a name="input_atom_security_group_egress"></a> [atom\_security\_group\_egress](#input\_atom\_security\_group\_egress) | Atom security group egress rules | <pre>list(object({<br>    from_port   = number<br>    to_port     = number<br>    description = string<br>    protocol    = string<br>    cidr_blocks = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "cidr_blocks": [<br>      "0.0.0.0/0"<br>    ],<br>    "description": "Unanet traffic",<br>    "from_port": 31001,<br>    "protocol": "tcp",<br>    "to_port": 31001<br>  }<br>]</pre> | no |
 | <a name="input_atom_version"></a> [atom\_version](#input\_atom\_version) | The version of the atom | `string` | `"4.3.5"` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region to deploy to | `string` | `"us-east-1"` | no |
+| <a name="input_boomi_environment_id"></a> [boomi\_environment\_id](#input\_boomi\_environment\_id) | The environment ID of the atom is to be attached | `string` | `""` | no |
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | The port of the container | `number` | `9090` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment to deploy to | `string` | `"prod"` | no |
 | <a name="input_owner"></a> [owner](#input\_owner) | The owner of the application | `string` | `"devsecops"` | no |

--- a/service.tf
+++ b/service.tf
@@ -8,7 +8,7 @@ resource "aws_ecs_task_definition" "task_definition" {
       },
       {
         name  = "BOOMI_ENVIRONMENTID"
-        value = var.environment
+        value = var.boomi_environment_id
       },
       {
         name  = "ATOM_LOCALHOSTID"

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,12 @@ variable "boomi_account_id" {
   type        = string
 }
 
+variable "boomi_environment_id" {
+  description = "The environment ID of the atom is to be attached"
+  default     = ""
+  type        = string
+}
+
 # Network variables
 variable "vpc_cidr" {
   description = "The CIDR block for the VPC"

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,7 @@ variable "boomi_account_id" {
 
 variable "boomi_environment_id" {
   description = "The environment ID of the atom is to be attached"
+  sensitive   = true
   default     = ""
   type        = string
 }


### PR DESCRIPTION
This adds the new environment id option to be passed to the boomi atom instance so it can register itself on updates.